### PR TITLE
feat: include tests.css if built

### DIFF
--- a/test/fixtures/imports-css.js
+++ b/test/fixtures/imports-css.js
@@ -1,0 +1,9 @@
+import "./style.css";
+
+describe("suite", () => {
+  it("should pass", () => {
+    // do nothing
+  });
+});
+
+console.log(`body background-color: ${window.getComputedStyle(document.body).backgroundColor}`);

--- a/test/fixtures/style.css
+++ b/test/fixtures/style.css
@@ -1,0 +1,3 @@
+body {
+  background-color: rgb(0, 255, 0);
+}

--- a/test/mocha-web.spec.ts
+++ b/test/mocha-web.spec.ts
@@ -145,4 +145,12 @@ describe("mocha-web", function () {
     expect(output).to.include("9 passing");
     expect(status).to.equal(0);
   });
+
+  it("includes tests.css if built by compilation", () => {
+    const { output, status } = runMochaPlay({ args: ["./imports-css.js"] });
+
+    expect(output).to.include("Found 1 test files");
+    expect(output, output).to.include("body background-color: rgb(0, 255, 0)");
+    expect(status).to.equal(0);
+  });
 });


### PR DESCRIPTION
esbuild supports css and css modules ootb, so support that if anyone wants to test ui code